### PR TITLE
Add license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "name": "Mike Bostock",
     "url": "http://bost.ocks.org/mike"
   },
+  "license": "BSD-3-Clause",
   "repository": {
     "type": "git",
     "url": "https://github.com/mbostock/queue.git"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/